### PR TITLE
Math equations rendered using MathJax library

### DIFF
--- a/src/lab/exp4/content.html
+++ b/src/lab/exp4/content.html
@@ -11,6 +11,12 @@ edit -->
 
 <head>
 <title>FLUORESCENCE VIRTUAL LAB</title>
+<script type="text/x-mathjax-config">
+	MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+	</script>
+	<script type="text/javascript" async
+		src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML">
+	</script>
 </head>
 
 <body>

--- a/src/lab/exp9/content.html
+++ b/src/lab/exp9/content.html
@@ -11,6 +11,12 @@ edit -->
 
 <head>
   <title>FLUORESCENCE VIRTUAL LAB</title>
+  	<script type="text/x-mathjax-config">
+	MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+	</script>
+	<script type="text/javascript" async
+		src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML">
+	</script>
 </head>
 
 <body>
@@ -195,8 +201,9 @@ where kr is the rate constant for fluorescence emission and knr is the sum of fi
 
 	The product k<sub>q</sub>[Q] is pseudo-first-order, where k<sub>q</sub>, is the second-order rate constant for quenching process and [Q] is the quencher concentration. Therefore, the de‑excitation pathways of the molecule M<sup>*</sup>, in the presence of quencher, Q, is given by
 
+
 \begin{equation}
-		k_{M^'} = k_r + k_{nr} + k_q [Q]= 1/τ_0 + k_q [Q]						
+		k_{M'} = k_r + k_{nr} + k_q [Q] = 1/τ_0 + k_q [Q]		
 \end{equation}
 
 		The fluorescence quantum yield in the absence of quencher (Φ0): 


### PR DESCRIPTION
Math symbols written in LaTeX now render properly using the MathJax Library.

Issues fixed:
#19  (Experiment 3) in commit 88d01fa0d6fc5805c3076a23ae454a9387fa3c7e

#23 (Experiment 9) in commit 39107b48e753cc379a3e84a583eb307b1bafca24